### PR TITLE
[stable] Pin resource-build script to known good commits of flannel and calico

### DIFF
--- a/build-canal-resources.sh
+++ b/build-canal-resources.sh
@@ -8,6 +8,8 @@ set -eux
 # in the charm store, see fetch-charm-store-resources.sh in this repository.
 
 ARCH=${ARCH:-"amd64 arm64"}
+CALICO_COMMIT="6560d51dd9e1f52e8b3ac8fd0660950dd42b9942"
+FLANNEL_COMMIT="735061b32aa913e9561d3eb30770771fdecbff32"
 
 # 'git' is required
 command -v git >/dev/null 2>&1 || { echo 'git: command not found'; exit 1; }
@@ -21,17 +23,17 @@ test -d "${canal_temp}" && rm -rf "${canal_temp}"
 mkdir -p "${canal_temp}"
 
 # calico
-git clone --depth 1 --single-branch --branch master \
-  $calico_repo "${canal_temp}/calico"
+git clone $calico_repo "${canal_temp}/calico"
 pushd ${canal_temp}/calico
+git checkout "$CALICO_COMMIT"
 ./build-calico-resource.sh
 mv calico-*.gz ${canal_root}
 popd
 
 # flannel
-git clone --depth 1 --single-branch --branch master \
-  $flannel_repo "${canal_temp}/flannel"
+git clone $flannel_repo "${canal_temp}/flannel"
 pushd ${canal_temp}/flannel
+git checkout "$FLANNEL_COMMIT"
 ARCH="$ARCH" ./build-flannel-resources.sh
 mv flannel-*.gz ${canal_root}
 popd


### PR DESCRIPTION
This will prevent `build-canal-resources.sh` pulling in unwanted changes from layer-calico and charm-flannel master branches.

Cherry-pick of https://github.com/charmed-kubernetes/layer-canal/pull/32, slightly tweaked to use older (stable) commits of layer-calico and charm-flannel.