### PR TITLE
Subordinate container runtime

### DIFF
--- a/build-canal-resources.sh
+++ b/build-canal-resources.sh
@@ -39,3 +39,5 @@ mv flannel-*.gz ${canal_root}
 popd
 
 test -d "${canal_temp}" && rm -rf "${canal_temp}"
+
+touch calico-node-image.tar.gz

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -49,3 +49,7 @@ resources:
     type: file
     filename: calico-upgrade.tar.gz
     description: 'calico-upgrade tool for arm64'
+  calico-node-image:
+    type: file
+    filename: calico-node-image.tar.gz
+    description: 'calico-node container image'

--- a/templates/calico-node.service
+++ b/templates/calico-node.service
@@ -1,36 +1,38 @@
 [Unit]
 Description=calico node
-After=docker.service
-Requires=docker.service
 
 [Service]
 User=root
 Environment=ETCD_ENDPOINTS={{ connection_string }}
 PermissionsStartOnly=true
-ExecStartPre=-/usr/bin/docker rm -f calico-node
-ExecStart=/usr/bin/docker run --net=host --privileged --name=calico-node \
-  -e ETCD_ENDPOINTS={{ connection_string }} \
-  -e ETCD_CA_CERT_FILE={{ etcd_ca_path }} \
-  -e ETCD_CERT_FILE={{ etcd_cert_path }} \
-  -e ETCD_KEY_FILE={{ etcd_key_path }} \
-  -e NODENAME={{ nodename }} \
-  -e IP={{ ip }} \
-  -e NO_DEFAULT_POOLS=true \
-  -e AS= \
-  -e CALICO_LIBNETWORK_ENABLED=true \
-  -e IP6= \
-  -e CALICO_NETWORKING_BACKEND=none \
-  -e FELIX_DEFAULTENDPOINTTOHOSTACTION=ACCEPT \
-  -v /lib/modules:/lib/modules \
-  -v /run/docker/plugins:/run/docker/plugins \
-  -v /var/run/calico:/var/run/calico \
-  -v /var/log/calico:/var/log/calico \
-  -v /var/lib/calico:/var/lib/calico \
-  -v /opt/calicoctl:/opt/calicoctl \
+ExecStartPre=-/usr/local/sbin/charm-env --charm calico conctl delete calico-node
+ExecStartPre=/bin/mkdir -p /var/run/calico /var/log/calico /var/lib/calico
+ExecStart=/usr/local/sbin/charm-env --charm calico conctl run \
+  --rm \
+  --net-host \
+  --privileged \
+  --env ETCD_ENDPOINTS={{ connection_string }} \
+  --env ETCD_CA_CERT_FILE={{ etcd_ca_path }} \
+  --env ETCD_CERT_FILE={{ etcd_cert_path }} \
+  --env ETCD_KEY_FILE={{ etcd_key_path }} \
+  --env NODENAME={{ nodename }} \
+  --env IP={{ ip }} \
+  --env NO_DEFAULT_POOLS=true \
+  --env AS= \
+  --env CALICO_LIBNETWORK_ENABLED=true \
+  --env IP6= \
+  --env CALICO_NETWORKING_BACKEND=bird \
+  --env FELIX_DEFAULTENDPOINTTOHOSTACTION=ACCEPT \
+  --mount /lib/modules:/lib/modules \
+  --mount /var/run/calico:/var/run/calico \
+  --mount /var/log/calico:/var/log/calico \
+  --mount /var/lib/calico:/var/lib/calico \
+  --mount /opt/calicoctl:/opt/calicoctl \
+  --name calico-node \
   {{ calico_node_image }}
-ExecStop=/usr/bin/docker rm -f calico-node
+ExecStop=-/usr/local/sbin/charm-env --charm calico conctl delete calico-node
 Restart=always
-RestartSec=10
+RestartSec=10e
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/calico-node.service
+++ b/templates/calico-node.service
@@ -5,9 +5,9 @@ Description=calico node
 User=root
 Environment=ETCD_ENDPOINTS={{ connection_string }}
 PermissionsStartOnly=true
-ExecStartPre=-/usr/local/sbin/charm-env --charm calico conctl delete calico-node
+ExecStartPre=-/usr/local/sbin/charm-env --charm canal conctl delete calico-node
 ExecStartPre=/bin/mkdir -p /var/run/calico /var/log/calico /var/lib/calico
-ExecStart=/usr/local/sbin/charm-env --charm calico conctl run \
+ExecStart=/usr/local/sbin/charm-env --charm canal conctl run \
   --rm \
   --net-host \
   --privileged \
@@ -30,7 +30,7 @@ ExecStart=/usr/local/sbin/charm-env --charm calico conctl run \
   --mount /opt/calicoctl:/opt/calicoctl \
   --name calico-node \
   {{ calico_node_image }}
-ExecStop=-/usr/local/sbin/charm-env --charm calico conctl delete calico-node
+ExecStop=-/usr/local/sbin/charm-env --charm canal conctl delete calico-node
 Restart=always
 RestartSec=10e
 

--- a/templates/calico-node.service
+++ b/templates/calico-node.service
@@ -21,7 +21,7 @@ ExecStart=/usr/local/sbin/charm-env --charm canal conctl run \
   --env AS= \
   --env CALICO_LIBNETWORK_ENABLED=true \
   --env IP6= \
-  --env CALICO_NETWORKING_BACKEND=bird \
+  --env CALICO_NETWORKING_BACKEND=none \
   --env FELIX_DEFAULTENDPOINTTOHOSTACTION=ACCEPT \
   --mount /lib/modules:/lib/modules \
   --mount /var/run/calico:/var/run/calico \
@@ -32,7 +32,7 @@ ExecStart=/usr/local/sbin/charm-env --charm canal conctl run \
   {{ calico_node_image }}
 ExecStop=-/usr/local/sbin/charm-env --charm canal conctl delete calico-node
 Restart=always
-RestartSec=10e
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,2 +1,3 @@
 charms.templating.jinja2>=1.0.0,<2.0.0
 python-etcd>=0.4.0,<1.0.0
+conctl==0.0.22


### PR DESCRIPTION
Tested:

```bash
Model    Controller     Cloud/Region   Version  SLA          Timestamp
default  aws-us-east-1  aws/us-east-1  2.6.4    unsupported  10:09:09-05:00

App                    Version       Status  Scale  Charm                  Store       Rev  OS      Notes
canal                  0.10.0/3.6.1  active      5  canal                  jujucharms    2  ubuntu  
containerd                           active      5  containerd             jujucharms    1  ubuntu  
easyrsa                3.0.1         active      1  easyrsa                jujucharms  254  ubuntu  
etcd                   3.2.10        active      3  etcd                   jujucharms  433  ubuntu  
kubeapi-load-balancer  1.14.0        active      1  kubeapi-load-balancer  jujucharms  648  ubuntu  exposed
kubernetes-master      1.15.0        active      2  kubernetes-master      jujucharms  699  ubuntu  
kubernetes-worker      1.15.0        active      3  kubernetes-worker      jujucharms  552  ubuntu  exposed

Unit                      Workload  Agent  Machine  Public address  Ports           Message
easyrsa/0*                active    idle   0        54.234.145.158                  Certificate Authority connected.
etcd/0*                   active    idle   1        18.212.99.198   2379/tcp        Healthy with 3 known peers
etcd/1                    active    idle   2        54.225.51.154   2379/tcp        Healthy with 3 known peers
etcd/2                    active    idle   3        3.219.29.194    2379/tcp        Healthy with 3 known peers
kubeapi-load-balancer/0*  active    idle   4        3.219.215.88    443/tcp         Loadbalancer ready.
kubernetes-master/0*      active    idle   5        54.82.39.55     6443/tcp        Kubernetes master running.
  canal/3                 active    idle            54.82.39.55                     Flannel subnet 10.1.4.1/24
  containerd/3            active    idle            54.82.39.55                     Container runtime available.
kubernetes-master/1       active    idle   6        3.88.56.197     6443/tcp        Kubernetes master running.
  canal/4                 active    idle            3.88.56.197                     Flannel subnet 10.1.80.1/24
  containerd/4            active    idle            3.88.56.197                     Container runtime available.
kubernetes-worker/0*      active    idle   7        3.87.173.52     80/tcp,443/tcp  Kubernetes worker running.
  canal/0*                active    idle            3.87.173.52                     Flannel subnet 10.1.31.1/24
  containerd/0*           active    idle            3.87.173.52                     Container runtime available.
kubernetes-worker/1       active    idle   8        54.237.154.17   80/tcp,443/tcp  Kubernetes worker running.
  canal/2                 active    idle            54.237.154.17                   Flannel subnet 10.1.65.1/24
  containerd/2            active    idle            54.237.154.17                   Container runtime available.
kubernetes-worker/2       active    idle   9        3.81.114.34     80/tcp,443/tcp  Kubernetes worker running.
  canal/1                 active    idle            3.81.114.34                     Flannel subnet 10.1.16.1/24
  containerd/1            active    idle            3.81.114.34                     Container runtime available.

Machine  State    DNS             Inst id              Series  AZ          Message
0        started  54.234.145.158  i-0b30bdd2240756aec  bionic  us-east-1a  running
1        started  18.212.99.198   i-0b9da61de654f4cbb  bionic  us-east-1a  running
2        started  54.225.51.154   i-01b7f0c7fc3e9ea43  bionic  us-east-1b  running
3        started  3.219.29.194    i-011088e9c8e2542bf  bionic  us-east-1c  running
4        started  3.219.215.88    i-07ad78e8c62d26cb0  bionic  us-east-1c  running
5        started  54.82.39.55     i-01bef8dc1374dbd3c  bionic  us-east-1a  running
6        started  3.88.56.197     i-03fe49917ee0159a6  bionic  us-east-1b  running
7        started  3.87.173.52     i-0ee208a69df288998  bionic  us-east-1a  running
8        started  54.237.154.17   i-0d3f8da5324c004b7  bionic  us-east-1c  running
9        started  3.81.114.34     i-05cd16ed71865eda7  bionic  us-east-1b  running
```