### PR TITLE
Detect and handle changes in etcd info

### DIFF
--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -250,6 +250,7 @@ def install_calico_service():
     etcd = endpoint_from_flag('etcd.available')
     etcd_connections = etcd.get_connection_string()
     data_changed('calico_etcd_connections', etcd_connections)
+    data_changed('calico_etcd_cert', etcd.get_client_credentials())
 
     service_path = os.path.join(os.sep, 'lib', 'systemd', 'system',
                                 'calico-node.service')
@@ -351,7 +352,11 @@ def ensure_etcd_connections():
     relevant flags to make sure accurate config is regenerated.
     '''
     etcd = endpoint_from_flag('etcd.available')
-    if data_changed('calico_etcd_connections', etcd.get_connection_string()):
+    connection_changed = data_changed('calico_etcd_connections',
+                                      etcd.get_connection_string())
+    cert_changed = data_changed('calico_etcd_cert',
+                                etcd.get_client_credentials())
+    if connection_changed or cert_changed:
         # NB: dont bother guarding clear_flag with is_flag_set; it's safe to
         # clear an unset flag.
         clear_flag('calico.service.installed')

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -330,7 +330,8 @@ def deploy_network_policy_controller(etcd, cni):
         'etcd_key_path': ETCD_KEY_PATH,
         'etcd_cert_path': ETCD_CERT_PATH,
         'etcd_ca_path': ETCD_CA_PATH,
-        'calico_policy_image': hookenv.config('calico-policy-image')
+        'calico_policy_image': hookenv.config('calico-policy-image'),
+        'etcd_cert_last_modified': os.path.getmtime(ETCD_CERT_PATH)
     }
     render('policy-controller.yaml', '/tmp/policy-controller.yaml', context)
     try:

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -357,6 +357,9 @@ def ensure_etcd_connections():
     cert_changed = data_changed('calico_etcd_cert',
                                 etcd.get_client_credentials())
     if connection_changed or cert_changed:
+        etcd.save_client_credentials(ETCD_KEY_PATH,
+                                     ETCD_CERT_PATH,
+                                     ETCD_CA_PATH)
         # NB: dont bother guarding clear_flag with is_flag_set; it's safe to
         # clear an unset flag.
         clear_flag('calico.service.installed')

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -257,11 +257,6 @@ def ensure_etcd_connections():
         # Clearing the above flag will change config that the flannel
         # service depends on. Set ourselves up to (re)invoke the start handler.
         clear_flag('flannel.service.started')
-        clear_flag('flannel.service.installed')
-
-        # Clearing the above flag will change config that the flannel
-        # service depends on. Set ourselves up to (re)invoke the start handler.
-        clear_flag('flannel.service.started')
 
 
 @hook('upgrade-charm')

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -249,6 +249,9 @@ def ensure_etcd_connections():
     cert_changed = data_changed('flannel_etcd_cert',
                                 etcd.get_client_credentials())
     if connection_changed or cert_changed:
+        etcd.save_client_credentials(ETCD_KEY_PATH,
+                                     ETCD_CERT_PATH,
+                                     ETCD_CA_PATH)
         clear_flag('flannel.service.installed')
 
         # Clearing the above flag will change config that the flannel

--- a/templates/policy-controller.yaml
+++ b/templates/policy-controller.yaml
@@ -111,6 +111,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-kube-controllers
+    cdk-restart-on-ca-change: "true"
 spec:
   # Only a single instance of the this pod should be
   # active at a time.  Since this pod is run as a Deployment,
@@ -125,6 +126,10 @@ spec:
       namespace: kube-system
       labels:
         k8s-app: calico-kube-controllers
+      annotations:
+        # annotate etcd cert modification time, so that when it changes, k8s
+        # will restart the pod
+        cdk-etcd-cert-last-modified: "{{ etcd_cert_last_modified }}"
     spec:
       hostNetwork: true
       serviceAccountName: calico-kube-controllers


### PR DESCRIPTION
The cert info for etcd can change as well as the connection string, and it also needs to trigger the service configs being updated and the services restarted.