### PR TITLE
Fix upgrade failure when leader is attached to k8s-master

### DIFF
--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -319,12 +319,13 @@ def reconfigure_calico_pool():
     remove_state('calico.pool.configured')
 
 
-@when('etcd.available', 'calico.service.installed', 'cni.is-worker',
+@when('etcd.available', 'calico.service.installed', 'leadership.is_leader',
       'leadership.set.calico-v3-data-ready')
 @when_not('calico.npc.deployed')
-def deploy_network_policy_controller(etcd, cni):
+def deploy_network_policy_controller():
     ''' Deploy the Calico network policy controller. '''
     status_set('maintenance', 'Deploying network policy controller.')
+    etcd = endpoint_from_flag('etcd.available')
     context = {
         'connection_string': etcd.get_connection_string(),
         'etcd_key_path': ETCD_KEY_PATH,


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-canal/+bug/1844605

I tested this with two deployments. For the first one, I did a direct deployment of the canonical-kubernetes-canal bundle from edge using a locally built canal, and ensured that the canal leader was attached to a kubernetes-worker unit. I verified that all calico services, and in particular the calico policy controller, were running.

For the second one, I tried to mimick the bug's failure conditions by deploying canonical-kubernetes-canal-484, ensuring that the canal leader was attached to a kubernetes-master unit, and then upgrading canal. I verified that all calico services upgraded correctly and that I could create new pods after the upgrade.