### PR TITLE
Bump to calico 3.10.1

### DIFF
--- a/build-canal-resources.sh
+++ b/build-canal-resources.sh
@@ -8,7 +8,7 @@ set -eux
 # in the charm store, see fetch-charm-store-resources.sh in this repository.
 
 ARCH=${ARCH:-"amd64 arm64"}
-CALICO_COMMIT="68b16354529b80afc6e938b8695c23764abefe55"
+CALICO_COMMIT="f6af5e29ded0fbf9da49e46d308895ff4fde28ad"
 FLANNEL_COMMIT="9dde517adde9b01d4cbb7ceb8004da097677ab31"
 
 # 'git' is required

--- a/build-canal-resources.sh
+++ b/build-canal-resources.sh
@@ -8,7 +8,7 @@ set -eux
 # in the charm store, see fetch-charm-store-resources.sh in this repository.
 
 ARCH=${ARCH:-"amd64 arm64"}
-CALICO_COMMIT="f6af5e29ded0fbf9da49e46d308895ff4fde28ad"
+CALICO_COMMIT="e114b47f5cb6a3e06ef70be590c01f11b0b8df74"
 FLANNEL_COMMIT="9dde517adde9b01d4cbb7ceb8004da097677ab31"
 
 # 'git' is required

--- a/config.yaml
+++ b/config.yaml
@@ -2,12 +2,12 @@ options:
   calico-node-image:
     type: string
     # Please refer to layer-canal/versioning.md before changing the version below.
-    default: rocks.canonical.com:443/cdk/calico/node:v3.6.1
+    default: rocks.canonical.com:443/cdk/calico/node:v3.10.1
     description: |
       The image id to use for calico/node.
   calico-policy-image:
     type: string
-    default: rocks.canonical.com:443/cdk/calico/kube-controllers:v3.6.1
+    default: rocks.canonical.com:443/cdk/calico/kube-controllers:v3.10.1
     description: |
       The image id to use for calico/kube-controllers.
   cidr:

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -5,7 +5,7 @@ import traceback
 
 from socket import gethostname
 from conctl import getContainerRuntimeCtl
-from subprocess import check_call, check_output, CalledProcessError
+from subprocess import check_call, check_output, CalledProcessError, STDOUT
 
 import calico_upgrade
 from charms.layer.canal import arch
@@ -381,7 +381,7 @@ def calicoctl(*args):
     env['ETCD_CERT_FILE'] = ETCD_CERT_PATH
     env['ETCD_CA_CERT_FILE'] = ETCD_CA_PATH
     try:
-        return check_output(cmd, env=env)
+        return check_output(cmd, env=env, stderr=STDOUT)
     except CalledProcessError as e:
         log(e.output)
         raise

--- a/reactive/canal.py
+++ b/reactive/canal.py
@@ -73,7 +73,7 @@ def set_canal_version():
     flannel_version = output.split('v')[-1].strip()
 
     # Please refer to layer-canal/versioning.md before changing this.
-    calico_version = '3.6.1'
+    calico_version = '3.10.1'
 
     version = '%s/%s' % (flannel_version, calico_version)
     application_version_set(version)

--- a/templates/policy-controller.yaml
+++ b/templates/policy-controller.yaml
@@ -7,7 +7,7 @@ metadata:
 # Include a clusterrole for the kube-controllers component,
 # and bind it to the calico-kube-controllers serviceaccount.
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-kube-controllers
 rules:
@@ -42,7 +42,7 @@ rules:
       - list
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-kube-controllers
 roleRef:
@@ -107,7 +107,7 @@ spec:
             path: /opt/calicoctl
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-node
 rules:
@@ -126,7 +126,7 @@ rules:
     verbs:
       - patch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: calico-node
@@ -139,7 +139,7 @@ subjects:
   name: calico-node
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: nodes-namespace-reader
@@ -152,7 +152,7 @@ roleRef:
   kind: ClusterRole
   name: namespace-reader
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: namespace-reader


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-calico/+bug/1854977 for Canal.

Tested by deploying this with `cs:~containers/canonical-kubernetes-canal` from edge. I ran validation and it passed:

```
$ pytest -s --no-print-logs -m 'not slow' --controller aws-vpc-0b87e1fedaca950f8 --model canal validation.py
...
=============================== warnings summary ===============================
jobs/integration/validation.py::test_dashboard
jobs/integration/validation.py::test_dashboard
jobs/integration/validation.py::test_kubelet_anonymous_auth_disabled
jobs/integration/validation.py::test_kubelet_anonymous_auth_disabled
  /usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:851: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    InsecureRequestWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===== 19 passed, 4 skipped, 1 deselected, 4 warnings in 1487.01s (0:24:47) =====
```

This is almost ready, but I want to wait until https://github.com/charmed-kubernetes/layer-calico/pull/50 is merged so I can put a more sensible CALICO_COMMIT in build-canal-resources.sh.