### PR TITLE
Fix conformance test failure due to IP masquerading

### DIFF
--- a/templates/flannel.service
+++ b/templates/flannel.service
@@ -5,7 +5,7 @@ Wants=network-online.target
 After=network.target network-online.target
 
 [Service]
-ExecStart=/usr/local/bin/flanneld -iface={{ iface }} -etcd-endpoints={{ connection_string }} -etcd-certfile={{ cert_path }}/client-cert.pem -etcd-keyfile={{ cert_path }}/client-key.pem  -etcd-cafile={{ cert_path }}/client-ca.pem
+ExecStart=/usr/local/bin/flanneld -iface={{ iface }} -etcd-endpoints={{ connection_string }} -etcd-certfile={{ cert_path }}/client-cert.pem -etcd-keyfile={{ cert_path }}/client-key.pem  -etcd-cafile={{ cert_path }}/client-ca.pem --ip-masq
 TimeoutStartSec=0
 Restart=on-failure
 LimitNOFILE=655536


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-canal/+bug/1859520 for canal.

For further explanation, see the equivalent PR to flannel: https://github.com/charmed-kubernetes/charm-flannel/pull/57

Tested with cs:~containers/canonical-kubernetes-canal stable, with canal built from this branch, and confirmed that the previously failing guestbook application test now succeeds.