### PR TITLE
Send cni-conf-file to cni relation

### DIFF
--- a/reactive/canal.py
+++ b/reactive/canal.py
@@ -56,7 +56,7 @@ def configure_cni():
         'subnet': subnet
     }
     render('10-canal.conflist', '/etc/cni/net.d/10-canal.conflist', context)
-    cni.set_config(cidr=config('cidr'))
+    cni.set_config(cidr=config('cidr'), cni_conf_file='10-canal.conflist')
     set_state('canal.cni.configured')
 
 


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/charm-kubernetes-master/+bug/1861709

Please be careful merging this, as it's mutually dependent on the work of other PRs in that issue. They will need to be merged together.

This updates canal to send cni-conf-file to the cni relation.