### PR TITLE
Add support for series upgrade

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -1,0 +1,22 @@
+name: Run tests with Tox
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Tox and any other packages
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e py  # Run tox using the version of Python in `PATH`

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.tox/
+__pycache__/
+*.pyc

--- a/layer.yaml
+++ b/layer.yaml
@@ -5,4 +5,5 @@ includes:
    - 'layer:basic'
    - 'layer:nagios'
    - 'layer:leadership'
+   - 'layer:status'
 repo: https://github.com/juju-solutions/layer-canal.git

--- a/reactive/canal.py
+++ b/reactive/canal.py
@@ -31,6 +31,11 @@ def upgrade_charm():
         hookenv.log(e)
 
 
+@hook('pre-series-upgrade')
+def pre_series_upgrade():
+    status_set('blocked', 'Series upgrade in progress')
+
+
 @when('etcd.available', 'cni.configured', 'flannel.service.started',
       'calico.service.installed', 'calico.pool.configured')
 @when_not('canal.cni.configured')

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -13,9 +13,11 @@ from charms.reactive.helpers import data_changed
 from charms.templating.jinja2 import render
 from charmhelpers.core.host import service_start, service_stop, service_restart
 from charmhelpers.core.host import service_running, service
-from charmhelpers.core.hookenv import log, status_set, resource_get, config
+from charmhelpers.core.hookenv import log, resource_get, config
 from charmhelpers.core.hookenv import network_get
 from charmhelpers.contrib.charmsupport import nrpe
+
+from charms.layer import status
 
 
 ETCD_PATH = '/etc/ssl/flannel'
@@ -39,20 +41,20 @@ def install_flannel_binaries():
     except Exception:
         message = 'Error fetching the flannel resource.'
         log(message)
-        status_set('blocked', message)
+        status.blocked(message)
         return
     if not archive:
         message = 'Missing flannel resource.'
         log(message)
-        status_set('blocked', message)
+        status.blocked(message)
         return
     filesize = os.stat(archive).st_size
     if filesize < 1000000:
         message = 'Incomplete flannel resource'
         log(message)
-        status_set('blocked', message)
+        status.blocked(message)
         return
-    status_set('maintenance', 'Unpacking flannel resource.')
+    status.maintenance('Unpacking flannel resource.')
     charm_dir = os.getenv('CHARM_DIR')
     unpack_path = os.path.join(charm_dir, 'files', 'flannel')
     os.makedirs(unpack_path, exist_ok=True)
@@ -120,7 +122,7 @@ def get_bind_address_interface():
 @when_not('flannel.service.installed')
 def install_flannel_service():
     ''' Install the flannel service. '''
-    status_set('maintenance', 'Installing flannel service.')
+    status.maintenance('Installing flannel service.')
 
     # keep track of our etcd connections so we can detect when it changes later
     etcd = endpoint_from_flag('etcd.tls.available')
@@ -149,12 +151,12 @@ def reconfigure_flannel_service():
 @when_not('flannel.network.configured')
 def invoke_configure_network(etcd):
     ''' invoke network configuration and adjust states '''
-    status_set('maintenance', 'Negotiating flannel network subnet.')
+    status.maintenance('Negotiating flannel network subnet.')
     if configure_network(etcd):
         set_state('flannel.network.configured')
         remove_state('flannel.service.started')
     else:
-        status_set('waiting', 'Waiting on etcd.')
+        status.waiting('Waiting on etcd.')
 
 
 @retry(times=3, delay_secs=20)
@@ -197,7 +199,7 @@ def reconfigure_network():
 @when_not('flannel.service.started')
 def start_flannel_service():
     ''' Start the flannel service. '''
-    status_set('maintenance', 'Starting flannel service.')
+    status.maintenance('Starting flannel service.')
     if service_running('flannel'):
         service_restart('flannel')
     else:
@@ -232,7 +234,7 @@ def update_nrpe_config(unused=None):
 @when_not('etcd.connected')
 def halt_execution():
     ''' send a clear message to the user that we are waiting on etcd '''
-    status_set('blocked', 'Waiting for etcd relation.')
+    status.blocked('Waiting for etcd relation.')
 
 
 @when('etcd.available', 'flannel.service.installed')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import charms.unit_test
+
+
+charms.unit_test.patch_reactive()
+charms.unit_test.patch_module('conctl')
+charms.unit_test.patch_module('charms.leadership')

--- a/tests/test_canal.py
+++ b/tests/test_canal.py
@@ -1,0 +1,7 @@
+from reactive import canal
+
+
+def test_series_upgrade():
+    assert canal.status_set.call_count == 0
+    canal.pre_series_upgrade()
+    assert canal.status_set.call_count == 1

--- a/tests/test_canal.py
+++ b/tests/test_canal.py
@@ -2,6 +2,6 @@ from reactive import canal
 
 
 def test_series_upgrade():
-    assert canal.status_set.call_count == 0
+    assert canal.status.blocked.call_count == 0
     canal.pre_series_upgrade()
-    assert canal.status_set.call_count == 1
+    assert canal.status.blocked.call_count == 1

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,6 @@
 skipsdist = True
 envlist = lint,py3
 
-[tox:travis]
-3.5: lint,py3
-3.6: lint,py3
-3.7: lint,py3
-
 [testenv]
 basepython = python3
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+skipsdist = True
+envlist = lint,py3
+
+[tox:travis]
+3.5: lint,py3
+3.6: lint,py3
+3.7: lint,py3
+
+[testenv]
+basepython = python3
+setenv =
+    PYTHONPATH={toxinidir}:{toxinidir}/lib
+deps =
+    pyyaml
+    pytest
+    flake8
+    ipdb
+    git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
+commands = pytest --tb native -s {posargs}
+
+[testenv:lint]
+envdir = {toxworkdir}/py3
+commands = flake8 {toxinidir}/lib {toxinidir}/reactive {toxinidir}/tests


### PR DESCRIPTION
We can't actually pause the service because the series upgrade hooks run on the subordinates before the principal so doing so could interfere with the pod drain process. So instead, we just set a status to let the Juju admin know that it's ok to proceed.

Part of https://bugs.launchpad.net/charm-canal/+bug/1869944