### PR TITLE
Fix failure to build etcdctl

### DIFF
--- a/build-canal-resources.sh
+++ b/build-canal-resources.sh
@@ -9,7 +9,7 @@ set -eux
 
 ARCH=${ARCH:-"amd64 arm64"}
 CALICO_COMMIT="5dab860987023b9b2570870b0f37d958bb7fd9b2"
-FLANNEL_COMMIT="9dde517adde9b01d4cbb7ceb8004da097677ab31"
+FLANNEL_COMMIT="4fb771339a8cc2cd48f33c1f1702203747debe30"
 
 # 'git' is required
 command -v git >/dev/null 2>&1 || { echo 'git: command not found'; exit 1; }


### PR DESCRIPTION
Golang 1.16.0 was released 3 days ago, and the Flannel/Canal charms' etcdctl builds have been failing since:

```
13:16:32 [canal] Building etcd v2.3.7 for amd64
13:16:32 [canal] + docker run --rm -e GOOS=linux -e GOARCH=amd64 -v /var/lib/jenkins/slaves/jenkins-slave-7/workspace/build-charms/.cache/charmbuild/jenkins-build-charms-999/charms/canal/tmp/temp/flannel/build-flannel-resources.tmp/etcd:/etcd golang /bin/bash -c 'cd /etcd && ./build && chown -R 999:999 /etcd'
...
13:16:50 [canal] no required module provides package github.com/coreos/etcd: working directory is not part of a module
```

This PR pulls in the fix from https://github.com/charmed-kubernetes/charm-flannel/pull/69.