### PR TITLE
Fix hook error due to missing kubernetes-common layer

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -6,4 +6,5 @@ includes:
    - 'layer:nagios'
    - 'layer:leadership'
    - 'layer:status'
+   - 'layer:kubernetes-common'
 repo: https://github.com/juju-solutions/layer-canal.git


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/1938943 for Canal.