### PR TITLE
Use cni.connected instead of deprecated cni.configured

### DIFF
--- a/reactive/canal.py
+++ b/reactive/canal.py
@@ -42,7 +42,7 @@ def pre_series_upgrade():
     status.blocked('Series upgrade in progress')
 
 
-@when('etcd.available', 'cni.configured', 'flannel.service.started',
+@when('etcd.available', 'cni.connected', 'flannel.service.started',
       'calico.service.installed', 'calico.pool.configured')
 @when_not('canal.cni.configured')
 def configure_cni():
@@ -55,7 +55,7 @@ def configure_cni():
         status.waiting('Waiting for Flannel')
         return
     os.makedirs('/etc/cni/net.d', exist_ok=True)
-    cni = endpoint_from_flag('cni.configured')
+    cni = endpoint_from_flag('cni.connected')
     etcd = endpoint_from_flag('etcd.available')
     cni_config = cni.get_config()
     context = {

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,12 @@ deps =
 commands = pytest --tb native -s {posargs} {toxinidir}/tests/unit
 
 [testenv:validate-wheelhouse]
+deps =
+# Temporarily pin setuptools to avoid the breaking change from 58 until
+# all dependencies we use have a chance to update. (tempita is the troublemaker for this repo).
+# See: https://setuptools.readthedocs.io/en/latest/history.html#v58-0-0
+# and: https://github.com/pypa/setuptools/issues/2784#issuecomment-917663223
+    setuptools<58
 allowlist_externals = {toxinidir}/tests/validate-wheelhouse.sh
 commands = {toxinidir}/tests/validate-wheelhouse.sh
 


### PR DESCRIPTION
With the removal of is_master from the CNI relation, the `cni.configured` flag will be removed as well since there is nothing left for kubernetes-master and kubernetes-worker to configure. Use `cni.connected` instead.

This is needed to support adding kubelet to kubernetes-master.