### PR TITLE
Switch from flannel v0.11.0 to v0.20.2.

### DIFF
--- a/build-canal-resources.sh
+++ b/build-canal-resources.sh
@@ -21,7 +21,7 @@ mkdir -p "${canal_temp}"
 # FLANNEL RESOURCES:
 # The flannel version in the canal and flannel charms are the same; use flannel's
 # build-flannel-resource.sh so we build identical resources for the canal charm.
-FLANNEL_COMMIT="5e3076746aeb86bddda8a920a6ec466e9511bae5"
+FLANNEL_COMMIT="16d6841f019acc4ff6e5b04059ff4bee6b50057e"
 FLANNEL_REPO="https://github.com/charmed-kubernetes/charm-flannel.git"
 
 git clone $FLANNEL_REPO "${canal_temp}/flannel"


### PR DESCRIPTION
Follows https://github.com/charmed-kubernetes/charm-flannel/pull/86 to address bug https://bugs.launchpad.net/charm-flannel/+bug/2004150, as [suggested](https://bugs.launchpad.net/charm-flannel/+bug/2004150/comments/3) by @kwmonroe.