### PR TITLE
Add flannel cni-plugin 1.2.0, update to flannel 0.22.1

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -61,12 +61,13 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.10'
 
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: vsphere
+          juju-channel: 3.1/stable
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2764"
@@ -88,7 +89,7 @@ jobs:
           name: calico-node-image-resources
 
       - name: Run integration test
-        run: tox -e integration
+        run: tox -e integration -- --basetemp=/home/ubuntu/pytest
 
       - name: Setup Debug Artifact Collection
         if: failure()

--- a/build-canal-resources.sh
+++ b/build-canal-resources.sh
@@ -18,7 +18,7 @@ mkdir -p "${canal_temp}"
 # FLANNEL RESOURCES:
 # The flannel version in the canal and flannel charms are the same; use flannel's
 # build-flannel-resource.sh so we build identical resources for the canal charm.
-FLANNEL_COMMIT="db7a8123e2391c412462bb1cd5bce721ff8dd268"
+FLANNEL_COMMIT="baa05960cc5fd2e6b6e00cd120dc6211036e9205"
 FLANNEL_REPO="https://github.com/charmed-kubernetes/charm-flannel.git"
 
 git clone $FLANNEL_REPO "${canal_temp}/flannel"

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -1,5 +1,6 @@
 import os
 import json
+import shutil
 from shlex import split
 from subprocess import check_output, check_call, CalledProcessError
 
@@ -68,6 +69,8 @@ def install_flannel_binaries():
         app_path = os.path.join(app["path"], app["name"])
         install = ["install", "-v", "-D", unpacked, app_path]
         check_call(install)
+    os.makedirs("/opt/cni/bin", exist_ok=True)
+    shutil.copy(unpack_path + "/cni-plugin/flannel", "/opt/cni/bin")
     set_state("flannel.binaries.installed")
 
 

--- a/tests/integration/test_canal_integration.py
+++ b/tests/integration/test_canal_integration.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 import shlex
+import shutil
 from ipaddress import ip_address, ip_network
 from pathlib import Path
 from time import sleep
@@ -85,7 +86,14 @@ async def test_build_and_deploy(ops_test, series: str, snap_channel: str):
     resources = list(Path.cwd().glob("flannel*.tar.gz")) + list(
         Path.cwd().glob("calico*.tar.gz")
     )
-    if not resources:
+    if resources:
+        log.info("Using pre-built resources...")
+        resource_dir = ops_test.tmp_path / "resources"
+        resource_dir.mkdir(exist_ok=True)
+        for resource in resources:
+            shutil.copy(resource, resource_dir)
+        resources = list(resource_dir.glob("*"))
+    else:
         log.info("Build Resources...")
         build_script = Path.cwd() / "build-canal-resources.sh"
         resources = await ops_test.build_resources(build_script, with_sudo=False)


### PR DESCRIPTION
https://bugs.launchpad.net/bugs/2007425

Make Canal work with CNI 1.2.0. The host-local plugin no longer accepts subnets with host bits set, so the main fix here is to strip host bits when configuring it (e.g. `10.1.50.1/24` -> `10.1.50.0/24`).

Installing the flannel CNI plugin isn't actually necessary since it's not used by Canal, but it seems nice to make available anyway.