### PR TITLE
CI: Update deprecated actions

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -33,17 +33,17 @@ jobs:
       - name: Build Resources
         run:  sudo ./build-canal-resources.sh
       - name: Upload flannel artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: flannel-resources
           path: ./flannel-*.tar.gz
       - name: Upload calico artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: calico-resources
           path: ./calico*.tar.gz
       - name: Upload calico-node-image artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: calico-node-image-resources
           path: ./calico-node-image.tar.gz
@@ -74,17 +74,17 @@ jobs:
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
 
       - name: Download flannel artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: flannel-resources
 
       - name: Download calico artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: calico-resources
 
       - name: Download calico-node-image artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: calico-node-image-resources
 
@@ -101,7 +101,7 @@ jobs:
 
       - name: Upload debug artifacts
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-run-artifacts
           path: tmp


### PR DESCRIPTION
actions/download-artifact and actions/upload-artifact v3 are now deprecated
and can no longer be used. We need to bump the version to v4.
