### PR TITLE
Pin RELEASE_BRANCH to release_1.36 on release_1.36

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -36,4 +36,4 @@ parts:
     - CHARM_LAYERS_DIR: $CRAFT_STAGE/tmp/layers/
     - CHARM_INTERFACES_DIR: $CRAFT_STAGE/tmp/interfaces/
     - LAYER_INDEX: https://raw.githubusercontent.com/charmed-kubernetes/layer-index/main/
-    - RELEASE_BRANCH: main
+    - RELEASE_BRANCH: release_1.36

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,3 +1,4 @@
 git+https://github.com/charmed-kubernetes/conctl@c1eaaac#egg=conctl
 charms.reactive==1.5.3
 setuptools==70.3.0
+pbr==7.0.3

--- a/tox.ini
+++ b/tox.ini
@@ -34,14 +34,14 @@ commands = {toxinidir}/tests/validate-wheelhouse.sh
 
 [testenv:format]
 deps =
-    black
+    black==25.11.0
 commands =
     black {toxinidir}/src {toxinidir}/tests
 
 [testenv:lint]
 deps =
     flake8
-    black
+    black==25.11.0
 commands =
     flake8 {toxinidir}/src {toxinidir}/tests
     black --check {toxinidir}/src {toxinidir}/tests


### PR DESCRIPTION
## Summary
- set `RELEASE_BRANCH` to `release_1.36` in `charmcraft.yaml`
- ensure reactive charm builds on `release_1.36` use the matching release branch for layer selection

## Testing
- verified `charmcraft.yaml` contains `RELEASE_BRANCH: release_1.36`
