### PR TITLE
feat: migrate from `rocks.c.c` to `ghcr.io`

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -2,12 +2,12 @@ options:
   calico-node-image:
     type: string
     # Please refer to layer-canal/versioning.md before changing the version below.
-    default: rocks.canonical.com:443/cdk/calico/node:v3.10.1
+    default: ghcr.io/canonical/cdk/calico/node:v3.10.1
     description: |
       The image id to use for calico/node.
   calico-policy-image:
     type: string
-    default: rocks.canonical.com:443/cdk/calico/kube-controllers:v3.10.1
+    default: ghcr.io/canonical/cdk/calico/kube-controllers:v3.10.1
     description: |
       The image id to use for calico/kube-controllers.
   cidr:

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,3 +1,4 @@
 git+https://github.com/charmed-kubernetes/conctl@c1eaaac#egg=conctl
 charms.reactive==1.5.3
 setuptools==70.3.0
+pbr==7.0.3

--- a/tests/integration/test_canal_integration.py
+++ b/tests/integration/test_canal_integration.py
@@ -49,7 +49,7 @@ async def _create_test_pod(model):
         "spec": {
             "containers": [
                 {
-                    "image": "rocks.canonical.com/cdk/busybox:1.32",
+                    "image": "ghcr.io/canonical/cdk/busybox:1.32",
                     "name": "test",
                     "args": ["echo", '"test"'],
                 }

--- a/tox.ini
+++ b/tox.ini
@@ -34,14 +34,14 @@ commands = {toxinidir}/tests/validate-wheelhouse.sh
 
 [testenv:format]
 deps =
-    black
+    black==25.11.0
 commands =
     black {toxinidir}/src {toxinidir}/tests
 
 [testenv:lint]
 deps =
     flake8
-    black
+    black==25.11.0
 commands =
     flake8 {toxinidir}/src {toxinidir}/tests
     black --check {toxinidir}/src {toxinidir}/tests


### PR DESCRIPTION
## Overview

Migrate the registry from `rocks.canonical.com` to `ghcr.io`.