### PR TITLE
fix: pin pbr==7.0.3 in wheelhouse.txt

### DIFF
--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,3 +1,4 @@
 git+https://github.com/charmed-kubernetes/conctl@c1eaaac#egg=conctl
 charms.reactive==1.5.3
 setuptools==70.3.0
+pbr==7.0.3


### PR DESCRIPTION
## What
Pins `pbr==7.0.3` in `src/wheelhouse.txt`.

## Why
The `validate-wheelhouse` CI check on #88 fails on both Python 3.10 and 3.12 because `pbr<6.1.1` (constraint pulled in by charm-tools) resolves to `pbr 6.1.0`, which fails to build from source:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

Explicitly pinning `pbr==7.0.3` avoids the broken 6.1.0 build and lets the wheelhouse resolve/install cleanly.

## Testing
- Targets `KU-6289-migrate-to-ghcr` directly so it can be merged into that branch before #88 lands on `main`.